### PR TITLE
Removed other skins of iCheck except for flat

### DIFF
--- a/vendor/assets/stylesheets/iCheck/all.scss
+++ b/vendor/assets/stylesheets/iCheck/all.scss
@@ -1,7 +1,7 @@
 /* iCheck plugin skins
 ----------------------------------- */
-@import url("minimal/_all.css");
 /*
+@import url("minimal/_all.css");
 @import url("minimal/minimal.css");
 @import url("minimal/red.css");
 @import url("minimal/green.css");
@@ -14,8 +14,8 @@
 @import url("minimal/purple.css");
 */
 
-@import url("square/_all.css");
 /*
+@import url("square/_all.css");
 @import url("square/square.css");
 @import url("square/red.css");
 @import url("square/green.css");
@@ -42,8 +42,8 @@
 @import url("flat/purple.css");
 */
 
-@import url("line/_all.css");
 /*
+@import url("line/_all.css");
 @import url("line/line.css");
 @import url("line/red.css");
 @import url("line/green.css");
@@ -55,7 +55,7 @@
 @import url("line/pink.css");
 @import url("line/purple.css");
 */
-
+/*
 @import url("polaris/polaris.css");
-
 @import url("futurico/futurico.css");
+*/


### PR DESCRIPTION
Getting the following errors as these Skins are not present on AdminLte. 

GET http://localhost:3000/assets/iCheck/minimal/_all.css 404 (Not Found) tickets:12
GET http://localhost:3000/assets/iCheck/square/_all.css 404 (Not Found) tickets:12
GET http://localhost:3000/assets/iCheck/line/_all.css 404 (Not Found) tickets:12
GET http://localhost:3000/assets/iCheck/polaris/polaris.css 404 (Not Found) tickets:12
GET http://localhost:3000/assets/iCheck/futurico/futurico.css 404 (Not Found) tickets:12

So removed them from import list. 
