### PR TITLE
Add RSpec testing setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in adminlte-rails.gemspec
 gemspec
+
+group :development, :test do
+  gem 'rspec'
+end

--- a/adminlte-rails.gemspec
+++ b/adminlte-rails.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.description = %q{AdminLTE is a premium Bootstrap theme for Backend.}
   s.license = 'MIT'
   s.files = `git ls-files`.split("\n")
-  s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.test_files = Dir['spec/**/*']
   s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 end

--- a/adminlte-rails.gemspec
+++ b/adminlte-rails.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
   s.files = `git ls-files`.split("\n")
   s.test_files = Dir['spec/**/*']
-  s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+require 'rspec'
+require 'adminlte-rails'
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'rspec'
 require 'adminlte-rails'
 
 RSpec.configure do |config|

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe AdminLTE::Rails::VERSION do
+RSpec.describe AdminLTE::Rails::VERSION do
   it 'is defined' do
     expect(AdminLTE::Rails::VERSION).not_to be_nil
   end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe AdminLTE::Rails::VERSION do
+  it 'is defined' do
+    expect(AdminLTE::Rails::VERSION).not_to be_nil
+  end
+end


### PR DESCRIPTION
## Summary
- add RSpec to development dependencies
- define spec helper
- test AdminLTE::Rails::VERSION constant
- list spec files in gemspec

## Testing
- `bundle exec rspec` *(fails: command not found)*
- `bundle install --local` *(fails: missing gems)*

------
https://chatgpt.com/codex/tasks/task_b_68708affc8dc832ea7c55b4c2fec3b2f